### PR TITLE
Add AvgProfile and compare command

### DIFF
--- a/cmd/analyze-xhprof.go
+++ b/cmd/analyze-xhprof.go
@@ -35,7 +35,7 @@ func analyzeXhprof(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var data map[string]xhprof.PairCall
+	var data map[string]*xhprof.PairCall
 	err = json.Unmarshal(rawData, &data)
 	if err != nil {
 		return err

--- a/cmd/compare-xhprof.go
+++ b/cmd/compare-xhprof.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/tideways/toolkit/xhprof"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(compareCmd)
+	xhprofCmd.Flags().IntVarP(&limit, "limit", "n", 10, "Number of rows to display")
+}
+
+var (
+	limit int
+)
+
+var compareCmd = &cobra.Command{
+	Use:   "compare-xhprof [options]... filepaths...",
+	Short: "Compare two JSON serialized XHProf outputs and display them in a sorted table.",
+	Long:  `Compare two JSON serialized XHProf outputs and display them in a sorted table.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  compare,
+}
+
+func compare(cmd *cobra.Command, args []string) error {
+	profiles := make([]*xhprof.Profile, 0, len(args))
+	for _, arg := range args {
+		rawData, err := ioutil.ReadFile(arg)
+		if err != nil {
+			return err
+		}
+
+		var data map[string]*xhprof.PairCall
+		err = json.Unmarshal(rawData, &data)
+		if err != nil {
+			return err
+		}
+
+		profile, err := xhprof.Flatten(data)
+		if err != nil {
+			return err
+		}
+
+		profiles = append(profiles, profile)
+	}
+
+	diff := profiles[0].Subtract(profiles[1])
+
+	err := renderProfileDiff(diff, limit)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -120,3 +120,30 @@ func getRow(call *xhprof.Call, fields []FieldInfo) []string {
 
 	return res
 }
+
+func renderProfileDiff(diff *xhprof.ProfileDiff, limit int) error {
+	diff.Sort()
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Function", "Wall-Time", "CPU-Time", "Fraction Wall-Time From", "Fraction Wall-Time To"})
+	for i, call := range diff.Calls {
+		if i >= limit {
+			break
+		}
+
+		row := []string{
+			fmt.Sprintf("%.90s", call.Name),
+			fmt.Sprintf("%2.2f ms", call.WallTime/1000),
+			fmt.Sprintf("%2.2f ms", call.CpuTime/1000),
+			fmt.Sprintf("%2.2f", call.FractionWtFrom),
+			fmt.Sprintf("%2.2f", call.FractionWtTo),
+		}
+
+		table.Append(row)
+	}
+
+	fmt.Printf("Showing XHProf data by the difference of fractions\n")
+	table.Render()
+
+	return nil
+}

--- a/xhprof/call.go
+++ b/xhprof/call.go
@@ -38,6 +38,30 @@ func (c *Call) Add(o *Call) *Call {
 	return c
 }
 
+func (c *Call) AddPairCall(p *PairCall) *Call {
+	c.Count += p.Count
+	c.WallTime += p.WallTime
+	c.ExclusiveWallTime += p.WallTime
+	c.CpuTime += p.CpuTime
+	c.ExclusiveCpuTime += p.CpuTime
+	c.IoTime += (p.WallTime - p.CpuTime)
+	c.ExclusiveIoTime += (p.WallTime - p.CpuTime)
+	c.Memory += p.Memory
+	c.PeakMemory += p.PeakMemory
+	c.ExclusiveMemory += p.Memory
+
+	return c
+}
+
+func (c *Call) SubtractExcl(p *PairCall) *Call {
+	c.ExclusiveWallTime -= p.WallTime
+	c.ExclusiveCpuTime -= p.CpuTime
+	c.ExclusiveMemory -= p.Memory
+	c.ExclusiveIoTime -= (p.WallTime - p.CpuTime)
+
+	return c
+}
+
 func (c *Call) Divide(d float32) *Call {
 	c.Count /= int(d)
 	c.WallTime /= d

--- a/xhprof/call.go
+++ b/xhprof/call.go
@@ -1,0 +1,54 @@
+package xhprof
+
+import (
+	"reflect"
+)
+
+type Call struct {
+	Name              string
+	Count             int
+	WallTime          float32
+	CpuTime           float32
+	IoTime            float32
+	Memory            float32
+	PeakMemory        float32
+	ExclusiveWallTime float32
+	ExclusiveCpuTime  float32
+	ExclusiveMemory   float32
+	ExclusiveIoTime   float32
+}
+
+func (c *Call) GetFloat32Field(field string) float32 {
+	cVal := reflect.Indirect(reflect.ValueOf(c))
+	return float32(cVal.FieldByName(field).Float())
+}
+
+func (c *Call) Add(o *Call) *Call {
+	c.Count += o.Count
+	c.WallTime += o.WallTime
+	c.ExclusiveWallTime += o.ExclusiveWallTime
+	c.CpuTime += o.CpuTime
+	c.ExclusiveCpuTime += o.ExclusiveCpuTime
+	c.Memory += o.Memory
+	c.PeakMemory += o.PeakMemory
+	c.ExclusiveMemory += o.ExclusiveMemory
+	c.IoTime += o.IoTime
+	c.ExclusiveIoTime += o.ExclusiveIoTime
+
+	return c
+}
+
+func (c *Call) Divide(d float32) *Call {
+	c.Count /= int(d)
+	c.WallTime /= d
+	c.ExclusiveWallTime /= d
+	c.CpuTime /= d
+	c.ExclusiveCpuTime /= d
+	c.Memory /= d
+	c.PeakMemory /= d
+	c.ExclusiveMemory /= d
+	c.IoTime /= d
+	c.ExclusiveIoTime /= d
+
+	return c
+}

--- a/xhprof/call.go
+++ b/xhprof/call.go
@@ -76,3 +76,11 @@ func (c *Call) Divide(d float32) *Call {
 
 	return c
 }
+
+type CallDiff struct {
+	Name           string
+	WallTime       float32
+	CpuTime        float32
+	FractionWtFrom float32
+	FractionWtTo   float32
+}

--- a/xhprof/call_test.go
+++ b/xhprof/call_test.go
@@ -68,6 +68,100 @@ func TestAdd(t *testing.T) {
 	assert.Equal(t, expected.ExclusiveMemory, c1.ExclusiveMemory)
 }
 
+func TestAddPairCall(t *testing.T) {
+	expected := Call{
+		Count:             5,
+		WallTime:          700,
+		ExclusiveWallTime: 600,
+		CpuTime:           300,
+		ExclusiveCpuTime:  250,
+		IoTime:            400,
+		ExclusiveIoTime:   350,
+		Memory:            512,
+		PeakMemory:        300,
+		ExclusiveMemory:   384,
+	}
+
+	c := &Call{
+		Count:             2,
+		WallTime:          300,
+		ExclusiveWallTime: 200,
+		CpuTime:           100,
+		ExclusiveCpuTime:  50,
+		IoTime:            200,
+		ExclusiveIoTime:   150,
+		Memory:            256,
+		ExclusiveMemory:   128,
+	}
+
+	p := &PairCall{
+		Count:      3,
+		WallTime:   400,
+		CpuTime:    200,
+		Memory:     256,
+		PeakMemory: 300,
+	}
+
+	c.AddPairCall(p)
+
+	assert.Equal(t, expected.Count, c.Count)
+	assert.Equal(t, expected.WallTime, c.WallTime)
+	assert.Equal(t, expected.ExclusiveWallTime, c.ExclusiveWallTime)
+	assert.Equal(t, expected.CpuTime, c.CpuTime)
+	assert.Equal(t, expected.ExclusiveCpuTime, c.ExclusiveCpuTime)
+	assert.Equal(t, expected.IoTime, c.IoTime)
+	assert.Equal(t, expected.ExclusiveIoTime, c.ExclusiveIoTime)
+	assert.Equal(t, expected.Memory, c.Memory)
+	assert.Equal(t, expected.PeakMemory, c.PeakMemory)
+	assert.Equal(t, expected.ExclusiveMemory, c.ExclusiveMemory)
+}
+
+func TestSubtractExcl(t *testing.T) {
+	expected := Call{
+		Count:             4,
+		WallTime:          500,
+		ExclusiveWallTime: 200,
+		CpuTime:           200,
+		ExclusiveCpuTime:  100,
+		IoTime:            300,
+		ExclusiveIoTime:   100,
+		Memory:            512,
+		ExclusiveMemory:   128,
+	}
+
+	c := &Call{
+		Count:             4,
+		WallTime:          500,
+		ExclusiveWallTime: 300,
+		CpuTime:           200,
+		ExclusiveCpuTime:  150,
+		IoTime:            300,
+		ExclusiveIoTime:   150,
+		Memory:            512,
+		ExclusiveMemory:   256,
+	}
+
+	p := &PairCall{
+		Count:    1,
+		WallTime: 100,
+		CpuTime:  50,
+		Memory:   128,
+	}
+
+	c.SubtractExcl(p)
+
+	assert.Equal(t, expected.Count, c.Count)
+	assert.Equal(t, expected.WallTime, c.WallTime)
+	assert.Equal(t, expected.ExclusiveWallTime, c.ExclusiveWallTime)
+	assert.Equal(t, expected.CpuTime, c.CpuTime)
+	assert.Equal(t, expected.ExclusiveCpuTime, c.ExclusiveCpuTime)
+	assert.Equal(t, expected.IoTime, c.IoTime)
+	assert.Equal(t, expected.ExclusiveIoTime, c.ExclusiveIoTime)
+	assert.Equal(t, expected.Memory, c.Memory)
+	assert.Equal(t, expected.PeakMemory, c.PeakMemory)
+	assert.Equal(t, expected.ExclusiveMemory, c.ExclusiveMemory)
+}
+
 func TestDivide(t *testing.T) {
 	expected := Call{
 		Count:             3,

--- a/xhprof/call_test.go
+++ b/xhprof/call_test.go
@@ -1,0 +1,107 @@
+package xhprof
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	expected := Call{
+		Count:             7,
+		WallTime:          1000,
+		ExclusiveWallTime: 600,
+		CpuTime:           500,
+		ExclusiveCpuTime:  300,
+		IoTime:            500,
+		ExclusiveIoTime:   300,
+		Memory:            1024,
+		ExclusiveMemory:   512,
+	}
+
+	c1 := &Call{
+		Count:             2,
+		WallTime:          300,
+		ExclusiveWallTime: 200,
+		CpuTime:           100,
+		ExclusiveCpuTime:  50,
+		IoTime:            200,
+		ExclusiveIoTime:   150,
+		Memory:            256,
+		ExclusiveMemory:   128,
+	}
+
+	c2 := &Call{
+		Count:             3,
+		WallTime:          400,
+		ExclusiveWallTime: 200,
+		CpuTime:           200,
+		ExclusiveCpuTime:  150,
+		IoTime:            200,
+		ExclusiveIoTime:   50,
+		Memory:            256,
+		ExclusiveMemory:   128,
+	}
+
+	c3 := &Call{
+		Count:             2,
+		WallTime:          300,
+		ExclusiveWallTime: 200,
+		CpuTime:           200,
+		ExclusiveCpuTime:  100,
+		IoTime:            100,
+		ExclusiveIoTime:   100,
+		Memory:            512,
+		ExclusiveMemory:   256,
+	}
+
+	c1.Add(c2).Add(c3)
+
+	assert.Equal(t, expected.Count, c1.Count)
+	assert.Equal(t, expected.WallTime, c1.WallTime)
+	assert.Equal(t, expected.ExclusiveWallTime, c1.ExclusiveWallTime)
+	assert.Equal(t, expected.CpuTime, c1.CpuTime)
+	assert.Equal(t, expected.ExclusiveCpuTime, c1.ExclusiveCpuTime)
+	assert.Equal(t, expected.IoTime, c1.IoTime)
+	assert.Equal(t, expected.ExclusiveIoTime, c1.ExclusiveIoTime)
+	assert.Equal(t, expected.Memory, c1.Memory)
+	assert.Equal(t, expected.ExclusiveMemory, c1.ExclusiveMemory)
+}
+
+func TestDivide(t *testing.T) {
+	expected := Call{
+		Count:             3,
+		WallTime:          900,
+		ExclusiveWallTime: 690,
+		CpuTime:           400,
+		ExclusiveCpuTime:  300,
+		IoTime:            500,
+		ExclusiveIoTime:   390,
+		Memory:            1024,
+		ExclusiveMemory:   512,
+	}
+
+	c1 := &Call{
+		Count:             10,
+		WallTime:          2700,
+		ExclusiveWallTime: 2070,
+		CpuTime:           1200,
+		ExclusiveCpuTime:  900,
+		IoTime:            1500,
+		ExclusiveIoTime:   1170,
+		Memory:            3072,
+		ExclusiveMemory:   1536,
+	}
+
+	c1.Divide(3)
+
+	assert.Equal(t, expected.Count, c1.Count)
+	assert.Equal(t, expected.WallTime, c1.WallTime)
+	assert.Equal(t, expected.ExclusiveWallTime, c1.ExclusiveWallTime)
+	assert.Equal(t, expected.CpuTime, c1.CpuTime)
+	assert.Equal(t, expected.ExclusiveCpuTime, c1.ExclusiveCpuTime)
+	assert.Equal(t, expected.IoTime, c1.IoTime)
+	assert.Equal(t, expected.ExclusiveIoTime, c1.ExclusiveIoTime)
+	assert.Equal(t, expected.Memory, c1.Memory)
+	assert.Equal(t, expected.ExclusiveMemory, c1.ExclusiveMemory)
+}

--- a/xhprof/paircall.go
+++ b/xhprof/paircall.go
@@ -13,7 +13,7 @@ type PairCall struct {
 	PeakMemory float32 `json:"pmu"`
 }
 
-func Flatten(data map[string]PairCall) (*Profile, error) {
+func Flatten(data map[string]*PairCall) (*Profile, error) {
 	var parent string
 	var child string
 
@@ -33,21 +33,7 @@ func Flatten(data map[string]PairCall) (*Profile, error) {
 			call = &Call{Name: child}
 		}
 
-		call.Count += info.Count
-
-		call.WallTime += info.WallTime
-		call.ExclusiveWallTime += info.WallTime
-
-		call.CpuTime += info.CpuTime
-		call.ExclusiveCpuTime += info.CpuTime
-
-		call.IoTime += (info.WallTime - info.CpuTime)
-		call.ExclusiveIoTime += (info.WallTime - info.CpuTime)
-
-		call.Memory += info.Memory
-		call.PeakMemory += info.PeakMemory
-		call.ExclusiveMemory += info.Memory
-
+		call.AddPairCall(info)
 		symbols[child] = call
 
 		if len(parent) == 0 {
@@ -58,11 +44,7 @@ func Flatten(data map[string]PairCall) (*Profile, error) {
 			call = &Call{Name: parent}
 		}
 
-		call.ExclusiveWallTime -= info.WallTime
-		call.ExclusiveCpuTime -= info.CpuTime
-		call.ExclusiveMemory -= info.Memory
-		call.ExclusiveIoTime -= (info.WallTime - info.CpuTime)
-
+		call.SubtractExcl(info)
 		symbols[parent] = call
 	}
 

--- a/xhprof/paircall.go
+++ b/xhprof/paircall.go
@@ -2,57 +2,8 @@ package xhprof
 
 import (
 	"errors"
-	"reflect"
-	"sort"
 	"strings"
 )
-
-type Call struct {
-	Name              string
-	Count             int
-	WallTime          float32
-	CpuTime           float32
-	IoTime            float32
-	Memory            float32
-	PeakMemory        float32
-	ExclusiveWallTime float32
-	ExclusiveCpuTime  float32
-	ExclusiveMemory   float32
-	ExclusiveIoTime   float32
-}
-
-func (i *Call) GetFloat32Field(field string) float32 {
-	iVal := reflect.Indirect(reflect.ValueOf(i))
-	return float32(iVal.FieldByName(field).Float())
-}
-
-type Profile struct {
-	Calls []*Call
-	Main  *Call
-}
-
-func (p *Profile) GetMain() *Call {
-	return p.Main
-}
-
-type ProfileByField struct {
-	Profile *Profile
-	Field   string
-}
-
-func (p ProfileByField) Len() int { return len(p.Profile.Calls) }
-func (p ProfileByField) Swap(i, j int) {
-	p.Profile.Calls[i], p.Profile.Calls[j] = p.Profile.Calls[j], p.Profile.Calls[i]
-}
-func (p ProfileByField) Less(i, j int) bool {
-	return p.Profile.Calls[i].GetFloat32Field(p.Field) > p.Profile.Calls[j].GetFloat32Field(p.Field)
-}
-
-func (p *Profile) SortBy(field string) error {
-	params := ProfileByField{Profile: p, Field: field}
-	sort.Sort(params)
-	return nil
-}
 
 type PairCall struct {
 	Count      int     `json:"ct"`

--- a/xhprof/paircall_test.go
+++ b/xhprof/paircall_test.go
@@ -10,7 +10,7 @@ import (
 func TestFlatten(t *testing.T) {
 	expected := []struct {
 		Name              string
-		Calls             int
+		Count             int
 		WallTime          float32
 		ExclusiveWallTime float32
 		CpuTime           float32
@@ -22,7 +22,7 @@ func TestFlatten(t *testing.T) {
 	}{
 		{
 			Name:              "main()",
-			Calls:             1,
+			Count:             1,
 			WallTime:          1000,
 			ExclusiveWallTime: 500,
 			CpuTime:           400,
@@ -34,7 +34,7 @@ func TestFlatten(t *testing.T) {
 		},
 		{
 			Name:              "foo",
-			Calls:             2,
+			Count:             2,
 			WallTime:          500,
 			ExclusiveWallTime: 300,
 			CpuTime:           200,
@@ -46,7 +46,7 @@ func TestFlatten(t *testing.T) {
 		},
 		{
 			Name:              "bar",
-			Calls:             10,
+			Count:             10,
 			WallTime:          200,
 			ExclusiveWallTime: 200,
 			CpuTime:           100,
@@ -58,43 +58,46 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 
-	sample := map[string]Info{
-		"main()": Info{
+	sample := map[string]PairCall{
+		"main()": PairCall{
 			WallTime: 1000,
-			Calls:    1,
+			Count:    1,
 			CpuTime:  400,
 			Memory:   1500,
 		},
-		"main()==>foo": Info{
+		"main()==>foo": PairCall{
 			WallTime: 500,
-			Calls:    2,
+			Count:    2,
 			CpuTime:  200,
 			Memory:   700,
 		},
-		"foo==>bar": Info{
+		"foo==>bar": PairCall{
 			WallTime: 200,
-			Calls:    10,
+			Count:    10,
 			CpuTime:  100,
 			Memory:   300,
 		},
 	}
 
-	profile := Flatten(sample)
+	profile, err := Flatten(sample)
+	profile.SortBy("WallTime")
 
-	var expectedType []FlatInfo
+	var expectedType *Profile
+	require.Nil(t, err)
 	require.IsType(t, profile, expectedType)
-	require.Len(t, profile, len(expected))
+	require.Len(t, profile.Calls, len(expected))
+	assert.Equal(t, float32(1000), profile.Main.WallTime)
 
-	for i, info := range profile {
-		assert.Equal(t, expected[i].Name, info.Name)
-		assert.Equal(t, expected[i].Calls, info.Calls)
-		assert.Equal(t, expected[i].WallTime, info.WallTime)
-		assert.Equal(t, expected[i].ExclusiveWallTime, info.ExclusiveWallTime)
-		assert.Equal(t, expected[i].CpuTime, info.CpuTime)
-		assert.Equal(t, expected[i].ExclusiveCpuTime, info.ExclusiveCpuTime)
-		assert.Equal(t, expected[i].Memory, info.Memory)
-		assert.Equal(t, expected[i].ExclusiveMemory, info.ExclusiveMemory)
-		assert.Equal(t, expected[i].IoTime, info.IoTime)
-		assert.Equal(t, expected[i].ExclusiveIoTime, info.ExclusiveIoTime)
+	for i, call := range profile.Calls {
+		assert.Equal(t, expected[i].Name, call.Name)
+		assert.Equal(t, expected[i].Count, call.Count)
+		assert.Equal(t, expected[i].WallTime, call.WallTime)
+		assert.Equal(t, expected[i].ExclusiveWallTime, call.ExclusiveWallTime)
+		assert.Equal(t, expected[i].CpuTime, call.CpuTime)
+		assert.Equal(t, expected[i].ExclusiveCpuTime, call.ExclusiveCpuTime)
+		assert.Equal(t, expected[i].Memory, call.Memory)
+		assert.Equal(t, expected[i].ExclusiveMemory, call.ExclusiveMemory)
+		assert.Equal(t, expected[i].IoTime, call.IoTime)
+		assert.Equal(t, expected[i].ExclusiveIoTime, call.ExclusiveIoTime)
 	}
 }

--- a/xhprof/paircall_test.go
+++ b/xhprof/paircall_test.go
@@ -58,20 +58,20 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 
-	sample := map[string]PairCall{
-		"main()": PairCall{
+	sample := map[string]*PairCall{
+		"main()": &PairCall{
 			WallTime: 1000,
 			Count:    1,
 			CpuTime:  400,
 			Memory:   1500,
 		},
-		"main()==>foo": PairCall{
+		"main()==>foo": &PairCall{
 			WallTime: 500,
 			Count:    2,
 			CpuTime:  200,
 			Memory:   700,
 		},
-		"foo==>bar": PairCall{
+		"foo==>bar": &PairCall{
 			WallTime: 200,
 			Count:    10,
 			CpuTime:  100,

--- a/xhprof/profile.go
+++ b/xhprof/profile.go
@@ -33,32 +33,27 @@ func (p *Profile) SortBy(field string) error {
 }
 
 func AvgProfiles(profiles []*Profile) *Profile {
-	type CallSum struct {
-		Call *Call
-		Num  int
-	}
-	callMap := make(map[string]*CallSum)
-
+	callMap := make(map[string]*Call)
 	for _, p := range profiles {
 		for _, c := range p.Calls {
 			call, ok := callMap[c.Name]
 			if !ok {
-				call = &CallSum{Call: new(Call), Num: 1}
-				*call.Call = *c
-				callMap[call.Call.Name] = call
+				call = new(Call)
+				*call = *c
+				callMap[call.Name] = call
 				continue
 			}
 
-			call.Call.Add(c)
-			call.Num += 1
+			call.Add(c)
 		}
 	}
 
+	num := float32(len(profiles))
 	res := new(Profile)
 	calls := make([]*Call, 0, len(callMap))
 	for _, call := range callMap {
-		avgCall := call.Call.Divide(float32(call.Num))
-		if call.Call.Name == "main()" {
+		avgCall := call.Divide(num)
+		if call.Name == "main()" {
 			res.Main = avgCall
 		}
 

--- a/xhprof/profile.go
+++ b/xhprof/profile.go
@@ -32,6 +32,96 @@ func (p *Profile) SortBy(field string) error {
 	return nil
 }
 
+func (p *Profile) Subtract(o *Profile) *ProfileDiff {
+	d := new(ProfileDiff)
+	diff := make(map[string]*CallDiff)
+
+	oCalls := make(map[string]*Call)
+	for _, c := range o.Calls {
+		oCalls[c.Name] = c
+	}
+
+	for _, c := range p.Calls {
+		if c == p.Main {
+			continue
+		}
+
+		oCall, ok := oCalls[c.Name]
+		if !ok {
+			callDiff := &CallDiff{
+				Name:           c.Name,
+				WallTime:       c.WallTime,
+				CpuTime:        c.CpuTime,
+				FractionWtFrom: c.WallTime / p.Main.WallTime,
+				FractionWtTo:   0,
+			}
+			diff[c.Name] = callDiff
+			continue
+		}
+
+		var wtChange float32
+		var cpuChange float32
+		if c.WallTime != oCall.WallTime {
+			wtChange = oCall.WallTime - c.WallTime
+		}
+		if c.CpuTime != oCall.CpuTime {
+			cpuChange = oCall.CpuTime - c.CpuTime
+		}
+
+		if wtChange != 0 || cpuChange != 0 {
+			callDiff := &CallDiff{
+				Name:           c.Name,
+				WallTime:       wtChange,
+				CpuTime:        cpuChange,
+				FractionWtFrom: c.WallTime / p.Main.WallTime,
+				FractionWtTo:   oCall.WallTime / o.Main.WallTime,
+			}
+			diff[c.Name] = callDiff
+		}
+
+		delete(oCalls, c.Name)
+	}
+
+	for _, c := range oCalls {
+		diff[c.Name] = &CallDiff{
+			Name:           c.Name,
+			WallTime:       c.WallTime,
+			CpuTime:        c.WallTime,
+			FractionWtFrom: 0,
+			FractionWtTo:   c.WallTime / o.Main.WallTime,
+		}
+	}
+
+	d.Calls = make([]*CallDiff, 0, len(diff))
+	for _, c := range diff {
+		d.Calls = append(d.Calls, c)
+	}
+
+	return d
+}
+
+type ProfileDiff struct {
+	Calls []*CallDiff
+}
+
+type ProfileDiffRelative ProfileDiff
+
+func (d ProfileDiffRelative) Len() int { return len(d.Calls) }
+func (d ProfileDiffRelative) Swap(i, j int) {
+	d.Calls[i], d.Calls[j] = d.Calls[j], d.Calls[i]
+}
+func (d ProfileDiffRelative) Less(i, j int) bool {
+	iFractionDiff := d.Calls[i].FractionWtFrom - d.Calls[i].FractionWtTo
+	jFractionDiff := d.Calls[j].FractionWtFrom - d.Calls[j].FractionWtTo
+
+	return iFractionDiff > jFractionDiff
+}
+
+func (d *ProfileDiff) Sort() {
+	params := ProfileDiffRelative(*d)
+	sort.Sort(params)
+}
+
 func AvgProfiles(profiles []*Profile) *Profile {
 	callMap := make(map[string]*Call)
 	for _, p := range profiles {

--- a/xhprof/profile.go
+++ b/xhprof/profile.go
@@ -1,0 +1,70 @@
+package xhprof
+
+import (
+	"sort"
+)
+
+type Profile struct {
+	Calls []*Call
+	Main  *Call
+}
+
+func (p *Profile) GetMain() *Call {
+	return p.Main
+}
+
+type ProfileByField struct {
+	Profile *Profile
+	Field   string
+}
+
+func (p ProfileByField) Len() int { return len(p.Profile.Calls) }
+func (p ProfileByField) Swap(i, j int) {
+	p.Profile.Calls[i], p.Profile.Calls[j] = p.Profile.Calls[j], p.Profile.Calls[i]
+}
+func (p ProfileByField) Less(i, j int) bool {
+	return p.Profile.Calls[i].GetFloat32Field(p.Field) > p.Profile.Calls[j].GetFloat32Field(p.Field)
+}
+
+func (p *Profile) SortBy(field string) error {
+	params := ProfileByField{Profile: p, Field: field}
+	sort.Sort(params)
+	return nil
+}
+
+func AvgProfiles(profiles []*Profile) *Profile {
+	type CallSum struct {
+		Call *Call
+		Num  int
+	}
+	callMap := make(map[string]*CallSum)
+
+	for _, p := range profiles {
+		for _, c := range p.Calls {
+			call, ok := callMap[c.Name]
+			if !ok {
+				call = &CallSum{Call: new(Call), Num: 1}
+				*call.Call = *c
+				callMap[call.Call.Name] = call
+				continue
+			}
+
+			call.Call.Add(c)
+			call.Num += 1
+		}
+	}
+
+	res := new(Profile)
+	calls := make([]*Call, 0, len(callMap))
+	for _, call := range callMap {
+		avgCall := call.Call.Divide(float32(call.Num))
+		if call.Call.Name == "main()" {
+			res.Main = avgCall
+		}
+
+		calls = append(calls, avgCall)
+	}
+	res.Calls = calls
+
+	return res
+}

--- a/xhprof/profile_test.go
+++ b/xhprof/profile_test.go
@@ -1,0 +1,91 @@
+package xhprof
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAvgProfiles(t *testing.T) {
+	expected := Profile{
+		Calls: []*Call{
+			&Call{
+				Name:              "main()",
+				Count:             2,
+				WallTime:          300,
+				ExclusiveWallTime: 200,
+				CpuTime:           150,
+				ExclusiveCpuTime:  100,
+				IoTime:            150,
+				ExclusiveIoTime:   100,
+				Memory:            256,
+				ExclusiveMemory:   128,
+			},
+		},
+	}
+
+	p1 := &Profile{
+		Calls: []*Call{
+			&Call{
+				Name:              "main()",
+				Count:             2,
+				WallTime:          200,
+				ExclusiveWallTime: 200,
+				CpuTime:           100,
+				ExclusiveCpuTime:  50,
+				IoTime:            100,
+				ExclusiveIoTime:   150,
+				Memory:            256,
+				ExclusiveMemory:   128,
+			},
+		},
+	}
+
+	p2 := &Profile{
+		Calls: []*Call{
+			&Call{
+				Name:              "main()",
+				Count:             3,
+				WallTime:          400,
+				ExclusiveWallTime: 200,
+				CpuTime:           200,
+				ExclusiveCpuTime:  150,
+				IoTime:            200,
+				ExclusiveIoTime:   50,
+				Memory:            256,
+				ExclusiveMemory:   128,
+			},
+		},
+	}
+
+	p3 := &Profile{
+		Calls: []*Call{
+			&Call{
+				Name:              "main()",
+				Count:             2,
+				WallTime:          300,
+				ExclusiveWallTime: 200,
+				CpuTime:           150,
+				ExclusiveCpuTime:  100,
+				IoTime:            150,
+				ExclusiveIoTime:   100,
+				Memory:            256,
+				ExclusiveMemory:   128,
+			},
+		},
+	}
+
+	p := AvgProfiles([]*Profile{p1, p2, p3})
+
+	require.Len(t, p.Calls, 1)
+	assert.Equal(t, expected.Calls[0].Count, p.Calls[0].Count)
+	assert.Equal(t, expected.Calls[0].WallTime, p.Calls[0].WallTime)
+	assert.Equal(t, expected.Calls[0].ExclusiveWallTime, p.Calls[0].ExclusiveWallTime)
+	assert.Equal(t, expected.Calls[0].CpuTime, p.Calls[0].CpuTime)
+	assert.Equal(t, expected.Calls[0].ExclusiveCpuTime, p.Calls[0].ExclusiveCpuTime)
+	assert.Equal(t, expected.Calls[0].IoTime, p.Calls[0].IoTime)
+	assert.Equal(t, expected.Calls[0].ExclusiveIoTime, p.Calls[0].ExclusiveIoTime)
+	assert.Equal(t, expected.Calls[0].Memory, p.Calls[0].Memory)
+	assert.Equal(t, expected.Calls[0].ExclusiveMemory, p.Calls[0].ExclusiveMemory)
+}


### PR DESCRIPTION
- [x] Moves type definitions and their methods to their own files
- [x] Adds `AvgProfiles`, which takes the union of the set of call infos, and divides their stats by the number of profiles (regardless in how many profiles they were present)
- [x] Modifies `analyze-xhprof` to accept multiple filepaths, and display the average of their profiles
- [x] Adds `ProfileDiff` and `CallDiff` types, which are returned by subtracting two profiles
- [x] Adds `compare-xhprof` command which subtracts exactly two profiles and displays the result
- [x] Add more test cases