### PR TITLE
Generate graphviz dot script of a xhprof profile

### DIFF
--- a/cmd/analyze-callgrind.go
+++ b/cmd/analyze-callgrind.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	RootCmd.AddCommand(analyzeCallgrindCmd)
 	analyzeCallgrindCmd.Flags().StringVarP(&field, "dimension", "d", "excl_wt", "Dimension to view/sort (wt, excl_wt)")
-	analyzeCallgrindCmd.Flags().Float32VarP(&minPercent, "min", "m", 1, "Display items having minimum percentage (default 1%) of --dimension, with respect to main()")
+	analyzeCallgrindCmd.Flags().Float32VarP(&minPercent, "min", "m", 1, "Display items having minimum percentage (default 1%) of --dimension, with respect to max value")
 }
 
 var analyzeCallgrindCmd = &cobra.Command{

--- a/cmd/analyze-xhprof.go
+++ b/cmd/analyze-xhprof.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	RootCmd.AddCommand(xhprofCmd)
 	xhprofCmd.Flags().StringVarP(&field, "dimension", "d", "excl_wt", "Dimension to view/sort (wt, excl_wt, cpu, excl_cpu, memory, excl_memory, io, excl_io)")
-	xhprofCmd.Flags().Float32VarP(&minPercent, "min", "m", 1, "Display items having minimum percentage (default 1% for inclusive, and 10% for exclusive dimensions) of --dimension, with respect to main()")
+	xhprofCmd.Flags().Float32VarP(&minPercent, "min", "m", 1, "Display items having minimum percentage (default 1% for inclusive, and 10% for exclusive dimensions) of --dimension, with respect to max value")
 	xhprofCmd.Flags().StringVarP(&outFile, "out-file", "o", "", "If provided, the path to store the resulting profile (e.g. after averaging)")
 	xhprofCmd.Flags().StringVarP(&function, "function", "", "", "If provided, one table for parents, and one for children of this function will be displayed")
 }

--- a/cmd/generate-xhprof-diff-graphviz.go
+++ b/cmd/generate-xhprof-diff-graphviz.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/tideways/toolkit/xhprof"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(generateXhprofDiffGraphvizCmd)
+	generateXhprofDiffGraphvizCmd.Flags().Float32VarP(&threshold, "threshold", "t", 1, "Display items having greater ratio of excl_wt (default 1%) with respect to main()")
+	generateXhprofDiffGraphvizCmd.Flags().StringVarP(&outFile, "out-file", "o", "callgraph.dot", "The path to store the resulting graph")
+}
+
+var generateXhprofDiffGraphvizCmd = &cobra.Command{
+	Use:   "generate-xhprof-diff-graphviz filepaths...",
+	Short: "Parse the output of two JSON serialized XHProf outputs, and generate a dot script out of their diff.",
+	Long:  `Parse the output of two JSON serialized XHProf outputs, and generate a dot script out of their diff.`,
+	Args:  cobra.ExactArgs(2),
+	RunE:  generateXhprofDiffGraphviz,
+}
+
+func generateXhprofDiffGraphviz(cmd *cobra.Command, args []string) error {
+	f := xhprof.NewFile(args[0], "xhprof")
+	m1, err := f.GetPairCallMap()
+	if err != nil {
+		return err
+	}
+
+	f = xhprof.NewFile(args[1], "xhprof")
+	m2, err := f.GetPairCallMap()
+	if err != nil {
+		return err
+	}
+
+	threshold /= 100
+	dot, err := xhprof.GenerateDiffDotScript(m1, m2, threshold)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(outFile, []byte(dot), 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/generate-xhprof-graphviz.go
+++ b/cmd/generate-xhprof-graphviz.go
@@ -44,7 +44,7 @@ func generateXhprofGraphviz(cmd *cobra.Command, args []string) error {
 	avgMap := xhprof.AvgPairCallMaps(maps)
 
 	threshold /= 100
-	dot, err := xhprof.GenerateDotScript(avgMap, threshold, function, criticalPath)
+	dot, err := xhprof.GenerateDotScript(avgMap, threshold, function, criticalPath, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/generate-xhprof-graphviz.go
+++ b/cmd/generate-xhprof-graphviz.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/tideways/toolkit/xhprof"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(generateXhprofGraphvizCmd)
+	generateXhprofGraphvizCmd.Flags().Float32VarP(&threshold, "threshold", "t", 1, "Display items having greater ratio of excl_wt (default 1%) with respect to main()")
+	generateXhprofGraphvizCmd.Flags().StringVarP(&function, "function", "f", "", "If provided, the graph will be generated only for functions directly related to this one")
+	generateXhprofGraphvizCmd.Flags().BoolVarP(&criticalPath, "critical-path", "", false, "If present, the critical path will be highlighted")
+	generateXhprofGraphvizCmd.Flags().StringVarP(&outFile, "out-file", "o", "callgraph.dot", "The path to store the resulting graph")
+}
+
+var (
+	threshold    float32
+	criticalPath bool
+)
+
+var generateXhprofGraphvizCmd = &cobra.Command{
+	Use:   "generate-xhprof-graphviz filepaths...",
+	Short: "Parse the output of JSON serialized XHProf outputs into a dot script for graphviz.",
+	Long:  `Parse the output of JSON serialized XHProf outputs into a dot script for graphviz.`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  generateXhprofGraphviz,
+}
+
+func generateXhprofGraphviz(cmd *cobra.Command, args []string) error {
+	maps := make([]*xhprof.PairCallMap, 0, len(args))
+	for _, arg := range args {
+		f := xhprof.NewFile(arg, "xhprof")
+		m, err := f.GetPairCallMap()
+		if err != nil {
+			return err
+		}
+
+		maps = append(maps, m)
+	}
+
+	avgMap := xhprof.AvgPairCallMaps(maps)
+
+	threshold /= 100
+	dot, err := xhprof.GenerateDotScript(avgMap, threshold, function, criticalPath)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(outFile, []byte(dot), 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/xhprof/call.go
+++ b/xhprof/call.go
@@ -16,6 +16,8 @@ type Call struct {
 	ExclusiveCpuTime  float32
 	ExclusiveMemory   float32
 	ExclusiveIoTime   float32
+
+	graphvizId int
 }
 
 func (c *Call) GetFloat32Field(field string) float32 {

--- a/xhprof/graphviz.go
+++ b/xhprof/graphviz.go
@@ -1,0 +1,187 @@
+package xhprof
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+func GenerateDotScript(m *PairCallMap, threshold float32, function string, criticalPath bool) (string, error) {
+	result := "digraph call_graph {\n"
+
+	maxWidth := float32(5)
+	maxHeight := float32(3.5)
+	maxFontSize := 35
+	maxSizingRatio := float32(20)
+
+	callMap := m.GetCallMap()
+	main, ok := callMap["main()"]
+	if !ok {
+		return "", errors.New("Call map has no main()")
+	}
+	mainWt := main.WallTime
+
+	var path map[string]bool
+	var pathEdges map[string]bool
+
+	if criticalPath {
+		path, pathEdges = getCriticalPath(m)
+	}
+
+	if function != "" {
+		relatedFuncs := getRelatedFuncs(m, function)
+		for name, _ := range callMap {
+			if _, ok := relatedFuncs[name]; !ok {
+				delete(relatedFuncs, name)
+			}
+		}
+	}
+
+	curId := 0
+	maxWt := float32(0)
+	for name, c := range callMap {
+		if function == "" && (c.WallTime/mainWt) < threshold {
+			delete(callMap, name)
+			continue
+		}
+
+		if maxWt == float32(0) || maxWt < c.ExclusiveWallTime {
+			maxWt = c.ExclusiveWallTime
+		}
+
+		c.graphvizId = curId
+		curId += 1
+	}
+
+	sizingFactor := float32(0)
+	for name, c := range callMap {
+		if c.ExclusiveWallTime == 0 {
+			sizingFactor = maxSizingRatio
+		} else {
+			sizingFactor = float32(math.Min(float64(maxWt/c.ExclusiveWallTime), float64(maxSizingRatio)))
+		}
+
+		fillColor := ""
+		if sizingFactor < 1.5 {
+			fillColor = ", style=filled, fillcolor=red"
+		}
+
+		if _, ok := path[name]; criticalPath && fillColor == "" && ok {
+			fillColor = ", style=filled, fillcolor=yellow"
+		}
+
+		fontSize := fmt.Sprintf(", fontsize=%d", int(float32(maxFontSize)/((sizingFactor-1)/10+1)))
+		width := fmt.Sprintf(", width=%.1f", maxWidth/sizingFactor)
+		height := fmt.Sprintf(", height=%.1f", maxHeight/sizingFactor)
+
+		shape := "box"
+		n := ""
+		if name == "main()" {
+			shape = "octagon"
+			n = fmt.Sprintf("Total: %2.2f ms \\nmain()", mainWt/1000)
+		} else {
+			n = fmt.Sprintf("%s\\nInc: %.3f ms (%.1f%%)", name, c.WallTime/1000, 100*c.WallTime/mainWt)
+		}
+
+		label := fmt.Sprintf(", label=\"%s\\nExcl: %.3f ms (%.1f%%)\\n%d total calls\"", n, c.ExclusiveWallTime/1000, 100*c.ExclusiveWallTime/mainWt, c.Count)
+		result += fmt.Sprintf("N%d[shape=%s %s%s%s%s%s];\n", c.graphvizId, shape, label, width, height, fontSize, fillColor)
+	}
+
+	for name, c := range m.M {
+		parent, child := parsePairName(name)
+
+		parentC, ok := callMap[parent]
+		if !ok {
+			continue
+		}
+
+		childC, ok := callMap[child]
+		if !ok {
+			continue
+		}
+
+		if function != "" && parent != function && child != function {
+			continue
+		}
+
+		label := "1 call"
+		if c.Count != 1 {
+			label = fmt.Sprintf("%d calls", c.Count)
+		}
+
+		headLabel := "0.0%"
+		if childC.WallTime > 0 {
+			headLabel = fmt.Sprintf("%.1f%%", 100*c.WallTime/childC.WallTime)
+		}
+
+		tailLabel := "0.0%"
+		if parentC.WallTime > 0 {
+			tailLabel = fmt.Sprintf("%.1f%%", 100*c.WallTime/(parentC.WallTime-parentC.ExclusiveWallTime))
+		}
+
+		lineWidth := 1
+		arrowSize := 1
+		if _, ok := pathEdges[name]; criticalPath && ok {
+			lineWidth = 10
+			arrowSize = 2
+		}
+
+		result += fmt.Sprintf(
+			"N%d -> N%d[arrowsize=%d, color=grey, style=\"setlinewidth(%d)\", label=\"%s\", headlabel=\"%s\", taillabel=\"%s\" ];\n",
+			parentC.graphvizId, childC.graphvizId, arrowSize, lineWidth, label, headLabel, tailLabel,
+		)
+	}
+
+	result += "\n}"
+
+	return result, nil
+}
+
+func getCriticalPath(m *PairCallMap) (map[string]bool, map[string]bool) {
+	path := make(map[string]bool)
+	pathEdges := make(map[string]bool)
+	visited := make(map[string]bool)
+	childrenMap := m.GetChildrenMap()
+	node := "main()"
+
+	for node != "" {
+		visited[node] = true
+		if children, ok := childrenMap[node]; ok {
+			maxChild := ""
+			for _, child := range children {
+				if _, ok := visited[child]; ok {
+					continue
+				}
+
+				if maxChild == "" || m.M[pairName(node, child)].WallTime > m.M[pairName(node, maxChild)].WallTime {
+					maxChild = child
+				}
+			}
+
+			if maxChild != "" {
+				path[maxChild] = true
+				pathEdges[pairName(node, maxChild)] = true
+			}
+
+			node = maxChild
+		} else {
+			node = ""
+		}
+	}
+
+	return path, pathEdges
+}
+
+func getRelatedFuncs(m *PairCallMap, f string) map[string]bool {
+	r := make(map[string]bool)
+
+	for name, _ := range m.M {
+		parent, child := parsePairName(name)
+		if parent == f || child == f {
+			r[parent] = true
+			r[child] = true
+		}
+	}
+
+	return r
+}

--- a/xhprof/graphviz.go
+++ b/xhprof/graphviz.go
@@ -40,13 +40,13 @@ func GenerateDotScript(m *PairCallMap, threshold float32, function string, criti
 	curId := 0
 	maxWt := float32(0)
 	for name, c := range callMap {
-		if function == "" && (c.WallTime/mainWt) < threshold {
+		if function == "" && float32(math.Abs(float64(c.WallTime/mainWt))) < threshold {
 			delete(callMap, name)
 			continue
 		}
 
-		if maxWt == float32(0) || maxWt < c.ExclusiveWallTime {
-			maxWt = c.ExclusiveWallTime
+		if maxWt == float32(0) || maxWt < float32(math.Abs(float64(c.ExclusiveWallTime))) {
+			maxWt = float32(math.Abs(float64(c.ExclusiveWallTime)))
 		}
 
 		c.graphvizId = curId
@@ -58,7 +58,7 @@ func GenerateDotScript(m *PairCallMap, threshold float32, function string, criti
 		if c.ExclusiveWallTime == 0 {
 			sizingFactor = maxSizingRatio
 		} else {
-			sizingFactor = float32(math.Min(float64(maxWt/c.ExclusiveWallTime), float64(maxSizingRatio)))
+			sizingFactor = float32(math.Min(float64(maxWt)/math.Abs(float64(c.ExclusiveWallTime)), float64(maxSizingRatio)))
 		}
 
 		fillColor := ""
@@ -193,7 +193,7 @@ func getCriticalPath(m *PairCallMap) (map[string]bool, map[string]bool) {
 					continue
 				}
 
-				if maxChild == "" || m.M[pairName(node, child)].WallTime > m.M[pairName(node, maxChild)].WallTime {
+				if maxChild == "" || float32(math.Abs(float64(m.M[pairName(node, child)].WallTime))) > float32(math.Abs(float64(m.M[pairName(node, maxChild)].WallTime))) {
 					maxChild = child
 				}
 			}

--- a/xhprof/paircall.go
+++ b/xhprof/paircall.go
@@ -32,6 +32,16 @@ func (p *PairCall) Divide(d float32) *PairCall {
 	return p
 }
 
+func (p *PairCall) Subtract(o *PairCall) *PairCall {
+	p.Count -= o.Count
+	p.WallTime -= o.WallTime
+	p.CpuTime -= o.CpuTime
+	p.Memory -= o.Memory
+	p.PeakMemory -= o.PeakMemory
+
+	return p
+}
+
 type NearestFamily struct {
 	Children      *PairCallMap
 	Parents       *PairCallMap
@@ -159,6 +169,34 @@ func (m *PairCallMap) GetChildrenMap() map[string][]string {
 		}
 
 		r[parent] = append(r[parent], child)
+	}
+
+	return r
+}
+
+func (m *PairCallMap) Copy() *PairCallMap {
+	r := NewPairCallMap()
+
+	for name, info := range m.M {
+		c := new(PairCall)
+		*c = *info
+		r.M[name] = c
+	}
+
+	return r
+}
+
+func (m *PairCallMap) Subtract(o *PairCallMap) *PairCallMap {
+	r := m.Copy()
+
+	for name, info := range o.M {
+		p, ok := r.M[name]
+		if !ok {
+			p = new(PairCall)
+			r.M[name] = p
+		}
+
+		p.Subtract(info)
 	}
 
 	return r

--- a/xhprof/paircall.go
+++ b/xhprof/paircall.go
@@ -70,13 +70,10 @@ func (m *PairCallMap) NewPairCall(name string) *PairCall {
 	return pc
 }
 
-func (m *PairCallMap) Flatten() *Profile {
-	var parent string
-	var child string
-
+func (m *PairCallMap) GetCallMap() map[string]*Call {
 	symbols := make(map[string]*Call)
 	for name, info := range m.M {
-		parent, child = parsePairName(name)
+		parent, child := parsePairName(name)
 
 		call, ok := symbols[child]
 		if !ok {
@@ -97,6 +94,12 @@ func (m *PairCallMap) Flatten() *Profile {
 		call.SubtractExcl(info)
 		symbols[parent] = call
 	}
+
+	return symbols
+}
+
+func (m *PairCallMap) Flatten() *Profile {
+	symbols := m.GetCallMap()
 
 	profile := new(Profile)
 	calls := make([]*Call, 0, len(symbols))
@@ -144,6 +147,21 @@ func (m *PairCallMap) ComputeNearestFamily(f string) *NearestFamily {
 	}
 
 	return family
+}
+
+func (m *PairCallMap) GetChildrenMap() map[string][]string {
+	r := make(map[string][]string)
+
+	for name, _ := range m.M {
+		parent, child := parsePairName(name)
+		if _, ok := r[parent]; !ok {
+			r[parent] = make([]string, 0, 1)
+		}
+
+		r[parent] = append(r[parent], child)
+	}
+
+	return r
 }
 
 func AvgPairCallMaps(maps []*PairCallMap) *PairCallMap {

--- a/xhprof/paircall_test.go
+++ b/xhprof/paircall_test.go
@@ -231,3 +231,63 @@ func TestComputeNearestFamily(t *testing.T) {
 
 	assert.EqualValues(t, expected, f)
 }
+
+func TestSubtractPairCallMaps(t *testing.T) {
+	expected := &PairCallMap{
+		M: map[string]*PairCall{
+			"main()": &PairCall{
+				WallTime: 500,
+				Count:    0,
+				CpuTime:  300,
+				Memory:   800,
+			},
+			"main()==>foo": &PairCall{
+				WallTime: 600,
+				Count:    2,
+				CpuTime:  300,
+				Memory:   900,
+			},
+			"foo==>bar": &PairCall{
+				WallTime: -300,
+				Count:    -10,
+				CpuTime:  -150,
+				Memory:   -300,
+			},
+		},
+	}
+	m1 := &PairCallMap{
+		M: map[string]*PairCall{
+			"main()": &PairCall{
+				WallTime: 800,
+				Count:    1,
+				CpuTime:  400,
+				Memory:   1000,
+			},
+			"main()==>foo": &PairCall{
+				WallTime: 600,
+				Count:    2,
+				CpuTime:  300,
+				Memory:   900,
+			},
+		},
+	}
+	m2 := &PairCallMap{
+		M: map[string]*PairCall{
+			"main()": &PairCall{
+				WallTime: 300,
+				Count:    1,
+				CpuTime:  100,
+				Memory:   200,
+			},
+			"foo==>bar": &PairCall{
+				WallTime: 300,
+				Count:    10,
+				CpuTime:  150,
+				Memory:   300,
+			},
+		},
+	}
+
+	diff := m1.Subtract(m2)
+	assert.EqualValues(t, expected, diff)
+}


### PR DESCRIPTION
- [x] Add command for generating dot script for a `PairCallMap` (which could be the average of multiple)
- [x] Add command for generating dot script for difference of two `PairCallMap`s

Graph for `xhprof/testdata/simple.xhprof`:
![simple](https://user-images.githubusercontent.com/1591639/35565281-3aef5132-05bd-11e8-836a-0943fc496515.png)

Graph for diff between `tests/data/wp-index.xhprof` and `tests/data/wp-index2.xhprof` with a threshold of 10%:
![callgraph](https://user-images.githubusercontent.com/1591639/35568016-8b6ac358-05c7-11e8-8d72-f4fb6630a587.png)

